### PR TITLE
saving cumulative readings for idm/netidm

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ rtlamr-collect provides data aggregation for rtlamr. This tool in tandem with rt
 ### Building
 Downloading and building rtlamr-collect is as easy as:
 
-	go get github.com/bemasher/rtlamr-collect
+	go get github.com/fcovatti/rtlamr-collect
 
 This will produce the binary `$GOPATH/bin/rtlamr-collect`. For convenience it's common to add `$GOPATH/bin` to the path.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ rtlamr-collect provides data aggregation for rtlamr. This tool in tandem with rt
 ### Building
 Downloading and building rtlamr-collect is as easy as:
 
-	go get github.com/fcovatti/rtlamr-collect
+	go get github.com/bemasher/rtlamr-collect
 
 This will produce the binary `$GOPATH/bin/rtlamr-collect`. For convenience it's common to add `$GOPATH/bin` to the path.
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/bemasher/rtlamr-collect
+module github.com/fcovatti/rtlamr-collect
 
 go 1.12
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/fcovatti/rtlamr-collect
+module github.com/bemasher/rtlamr-collect
 
 go 1.12
 

--- a/main.go
+++ b/main.go
@@ -83,10 +83,10 @@ func (idm IDM) AddPoints(msg LogMessage, bp client.BatchPoints) {
 
 	// Total consumption
 	consumption := 0
-	if msg.type == "NetIDM" {
-	    consumption := idm.NetConsumption
+	if msg.Type == "NetIDM" {
+		consumption := idm.NetConsumption
 	} else {
-	    consumption := idm.CountConsumption
+		consumption := idm.CountConsumption
 	}
 
 	pt, err := client.NewPoint(

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ package main
 
 import (
 	"bufio"
-//	"encoding/binary"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -75,8 +75,9 @@ func (idm IDM) AddPoints(msg LogMessage, bp client.BatchPoints) {
 	}
 
 	// Convert outage flags (6 bytes) to uint64 (8 bytes)
-	// FIXME: crashes for netidm meters
-	//outage := binary.BigEndian.Uint64(append(make([]byte, 2), idm.Outage...))
+	outageBytes := make([]uint8, 8)
+	copy(outageBytes[2:], idm.Outage)
+	outage := binary.BigEndian.Uint64(outageBytes)
 
 	// For each differential interval.
 	for idx, usage := range idm.IntervalDiff {
@@ -111,11 +112,9 @@ func (idm IDM) AddPoints(msg LogMessage, bp client.BatchPoints) {
 		}
 
 		// If the outage bit corresponding to this interval is 1, add it to the field.
-		// FIXME
-		//if (outage>>uint(46-idx))&1 == 1 {
-		//	fields["outage"] = int64(1)
-		//}
-		fields["outage"] = int64(1)
+		if (outage>>uint(46-idx))&1 == 1 {
+			fields["outage"] = int64(1)
+		}
 
 		pt, err := client.NewPoint(
 			measurement,

--- a/main.go
+++ b/main.go
@@ -82,7 +82,7 @@ func (idm IDM) AddPoints(msg LogMessage, bp client.BatchPoints) {
 	outage := binary.BigEndian.Uint64(outageBytes)
 
 	// Total consumption
-	consumption := 0
+	consumption := uint32(0)
 	if msg.Type == "NetIDM" {
 		consumption = idm.NetConsumption
 	} else {

--- a/main.go
+++ b/main.go
@@ -84,9 +84,9 @@ func (idm IDM) AddPoints(msg LogMessage, bp client.BatchPoints) {
 	// Total consumption
 	consumption := 0
 	if msg.Type == "NetIDM" {
-		consumption := idm.NetConsumption
+		consumption = idm.NetConsumption
 	} else {
-		consumption := idm.CountConsumption
+		consumption = idm.CountConsumption
 	}
 
 	pt, err := client.NewPoint(

--- a/main.go
+++ b/main.go
@@ -75,7 +75,8 @@ func (idm IDM) AddPoints(msg LogMessage, bp client.BatchPoints) {
 	}
 
 	// Convert outage flags (6 bytes) to uint64 (8 bytes)
-	outage := binary.BigEndian.Uint64(append(make([]byte, 2), idm.Outage...))
+	// FIXME: crashes for netidm meters
+	//outage := binary.BigEndian.Uint64(append(make([]byte, 2), idm.Outage...))
 
 	// For each differential interval.
 	for idx, usage := range idm.IntervalDiff {
@@ -110,9 +111,11 @@ func (idm IDM) AddPoints(msg LogMessage, bp client.BatchPoints) {
 		}
 
 		// If the outage bit corresponding to this interval is 1, add it to the field.
-		if (outage>>uint(46-idx))&1 == 1 {
-			fields["outage"] = int64(1)
-		}
+		// FIXME
+		//if (outage>>uint(46-idx))&1 == 1 {
+		//	fields["outage"] = int64(1)
+		//}
+		fields["outage"] = int64(1)
 
 		pt, err := client.NewPoint(
 			measurement,

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ package main
 
 import (
 	"bufio"
-	"encoding/binary"
+//	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"log"


### PR DESCRIPTION
I did some changes in rtlamr-collect in order to save also the cumulative energy readings for IDM and NetIDM meters. In this way it is possible to have both differential and cumulative on the influx database.

I am not sure if you want to merge this, but I am creating the pull request so you can check if it is interesting to merge. I did test on Itron meters and the total consumption values worked.