### PR TITLE
Minor README Fix for New Versions of Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ rtlamr-collect provides data aggregation for rtlamr. This tool in tandem with rt
 ### Building
 Downloading and building rtlamr-collect is as easy as:
 
-	go get github.com/bemasher/rtlamr-collect
+	go install github.com/bemasher/rtlamr-collect@latest
 
 This will produce the binary `$GOPATH/bin/rtlamr-collect`. For convenience it's common to add `$GOPATH/bin` to the path.
 


### PR DESCRIPTION
Attempting to follow the README as written results in:

```
>go get github.com/bemasher/rtlamr-collect
go: go.mod file not found in current directory or any parent directory.
        'go get' is no longer supported outside a module.
        To build and install a command, use 'go install' with a version,
        like 'go install example.com/cmd@latest'
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
```

Make the minor README change to reflect the modification to `go install`